### PR TITLE
Build urdf with rpy

### DIFF
--- a/UnitTests/testUrdfParser.cpp
+++ b/UnitTests/testUrdfParser.cpp
@@ -5,9 +5,10 @@
 
 using namespace grbda;
 
-const std::string urdf_directory = "/home/matt/repos/URDF-Parser/";
+// const std::string urdf_directory = "/home/matt/repos/URDF-Parser/";
 // const std::string urdf_directory = "/Users/matthewchignoli/repos/URDF-Parser/";
-
+// const std::string urdf_directory = "/home/user/git/Robot-Software.worktrees/454-automate-system-id/third-parties/generalized_rbda/third-parties/URDF-Parser/examples/";
+const std::string urdf_directory = "/home/user/git/Robot-Software.worktrees/454-automate-system-id/config/robot_models/";
 struct URDFParserTestData
 {
     std::string urdf_file;
@@ -155,4 +156,22 @@ TEST_P(URDFvsManualTests, compareToManuallyConstructed)
         const DVec<double> tau_urdf = this->urdf_model.inverseDynamics(ydd);
         GTEST_ASSERT_LT((tau_manual - tau_urdf).norm(), tol);
     }
+}
+
+TEST(CasadiURDF, load){
+    ClusterTreeModel<casadi::SX> model_quat = ClusterTreeModel<casadi::SX>();
+    model_quat.buildModelFromURDF(urdf_directory + "mit_humanoid.urdf", true);
+    
+    ClusterTreeModel<casadi::SX> model_rpy = ClusterTreeModel<casadi::SX>();
+    model_rpy.buildModelFromURDF<ori_representation::RollPitchYaw>({urdf_directory + "mit_humanoid.urdf"}, true);
+
+    const std::vector<std::string> urdf_paths =
+        {urdf_directory +  "mit_humanoid_torso.urdf",
+         urdf_directory +  "mit_humanoid_right_leg_sys_id.urdf",
+         urdf_directory +  "mit_humanoid_left_leg_sys_id.urdf",
+         urdf_directory +  "mit_humanoid_right_arm.urdf",
+         urdf_directory +  "mit_humanoid_left_arm.urdf"};
+
+    ClusterTreeModel<casadi::SX> model_rpy_combined = ClusterTreeModel<casadi::SX>();
+    model_rpy_combined.buildModelFromURDF<ori_representation::RollPitchYaw>(urdf_paths, true);
 }

--- a/UnitTests/testUrdfParser.cpp
+++ b/UnitTests/testUrdfParser.cpp
@@ -5,9 +5,8 @@
 
 using namespace grbda;
 
-// const std::string urdf_directory = "/home/matt/repos/URDF-Parser/";
+const std::string urdf_directory = "/home/matt/repos/URDF-Parser/";
 // const std::string urdf_directory = "/Users/matthewchignoli/repos/URDF-Parser/";
-// const std::string urdf_directory = "/home/user/git/Robot-Software.worktrees/454-automate-system-id/third-parties/generalized_rbda/third-parties/URDF-Parser/examples/";
 const std::string urdf_directory = "/home/user/git/Robot-Software.worktrees/454-automate-system-id/config/robot_models/";
 struct URDFParserTestData
 {
@@ -156,22 +155,4 @@ TEST_P(URDFvsManualTests, compareToManuallyConstructed)
         const DVec<double> tau_urdf = this->urdf_model.inverseDynamics(ydd);
         GTEST_ASSERT_LT((tau_manual - tau_urdf).norm(), tol);
     }
-}
-
-TEST(CasadiURDF, load){
-    ClusterTreeModel<casadi::SX> model_quat = ClusterTreeModel<casadi::SX>();
-    model_quat.buildModelFromURDF(urdf_directory + "mit_humanoid.urdf", true);
-    
-    ClusterTreeModel<casadi::SX> model_rpy = ClusterTreeModel<casadi::SX>();
-    model_rpy.buildModelFromURDF<ori_representation::RollPitchYaw>({urdf_directory + "mit_humanoid.urdf"}, true);
-
-    const std::vector<std::string> urdf_paths =
-        {urdf_directory +  "mit_humanoid_torso.urdf",
-         urdf_directory +  "mit_humanoid_right_leg_sys_id.urdf",
-         urdf_directory +  "mit_humanoid_left_leg_sys_id.urdf",
-         urdf_directory +  "mit_humanoid_right_arm.urdf",
-         urdf_directory +  "mit_humanoid_left_arm.urdf"};
-
-    ClusterTreeModel<casadi::SX> model_rpy_combined = ClusterTreeModel<casadi::SX>();
-    model_rpy_combined.buildModelFromURDF<ori_representation::RollPitchYaw>(urdf_paths, true);
 }

--- a/UnitTests/testUrdfParser.cpp
+++ b/UnitTests/testUrdfParser.cpp
@@ -7,7 +7,7 @@ using namespace grbda;
 
 const std::string urdf_directory = "/home/matt/repos/URDF-Parser/";
 // const std::string urdf_directory = "/Users/matthewchignoli/repos/URDF-Parser/";
-const std::string urdf_directory = "/home/user/git/Robot-Software.worktrees/454-automate-system-id/config/robot_models/";
+
 struct URDFParserTestData
 {
     std::string urdf_file;

--- a/include/grbda/Dynamics/ClusterTreeModel.h
+++ b/include/grbda/Dynamics/ClusterTreeModel.h
@@ -55,8 +55,24 @@ namespace grbda
         }
         ~ClusterTreeModel() {}
 
-        void buildModelFromURDF(const std::string &urdf_filename, bool floating_base);
-        void buildModelFromURDF(const std::vector<std::string> &urdf_filenames, bool floating_base);
+        
+        template <typename OrientationRepresentation = ori_representation::Quaternion>
+        void buildModelFromURDF(
+            const std::string &urdf_filename, bool floating_base)
+        {
+            std::shared_ptr<urdf::ModelInterface> model;
+            model = urdf::parseURDFFile(urdf_filename, false);
+            buildFromUrdfModelInterface<OrientationRepresentation>(model, floating_base);
+        }
+        
+        template <typename OrientationRepresentation = ori_representation::Quaternion>
+        void buildModelFromURDF(
+            const std::vector<std::string> &urdf_filenames, bool floating_base)
+        {
+            std::shared_ptr<urdf::ModelInterface> model;
+            model = urdf::parseURDFFiles(urdf_filenames, false);
+            buildFromUrdfModelInterface<OrientationRepresentation>(model, floating_base);
+        }
 
         // The standard process for appending a cluster to the tree is to register all the bodies
         // in  given cluster and then append them as a cluster by specifying the type of cluster
@@ -171,7 +187,9 @@ namespace grbda
         // TODO(@MatthewChignoli): Is this bad? Maybe
         using SX = casadi::SX;
 
+        template <typename OrientationRepresentation = ori_representation::Quaternion>
         void buildFromUrdfModelInterface(const UrdfModelPtr model, bool floating_base);
+        
         void appendClustersViaDFS(std::map<UrdfClusterPtr, bool> &visited, UrdfClusterPtr cluster);
         void appendClusterFromUrdfCluster(UrdfClusterPtr cluster);
         void appendSimpleRevoluteJointFromUrdfCluster(UrdfLinkPtr link);

--- a/include/grbda/Utils/SpatialInertia.h
+++ b/include/grbda/Utils/SpatialInertia.h
@@ -49,6 +49,13 @@ namespace grbda
       return *this;
     }
 
+    Vec10<Scalar> toVector() const
+    {
+      Vec10<Scalar> v;
+      v << m, h, I(0, 0), I(0, 1), I(0, 2), I(1, 1), I(1, 2), I(2, 2);
+      return v;
+    }
+
   };
 
   /*!

--- a/include/grbda/Utils/cppTypes.h
+++ b/include/grbda/Utils/cppTypes.h
@@ -34,6 +34,10 @@ namespace grbda
     template <typename T>
     using Vec7 = typename Eigen::Matrix<T, 7, 1>;
 
+    // 10x1 Vector
+    template <typename T>
+    using Vec10 = typename Eigen::Matrix<T, 10, 1>;
+
     // 2x2 Matrix
     template <typename T>
     using Mat2 = typename Eigen::Matrix<T, 2, 2>;

--- a/src/Dynamics/ClusterTreeParsing.cpp
+++ b/src/Dynamics/ClusterTreeParsing.cpp
@@ -2,25 +2,10 @@
 
 namespace grbda
 {
-    template <typename Scalar>
-    void ClusterTreeModel<Scalar>::buildModelFromURDF(
-        const std::string &urdf_filename, bool floating_base)
-    {
-        std::shared_ptr<urdf::ModelInterface> model;
-        model = urdf::parseURDFFile(urdf_filename, false);
-        buildFromUrdfModelInterface(model, floating_base);
-    }
+
 
     template <typename Scalar>
-    void ClusterTreeModel<Scalar>::buildModelFromURDF(
-        const std::vector<std::string> &urdf_filenames, bool floating_base)
-    {
-        std::shared_ptr<urdf::ModelInterface> model;
-        model = urdf::parseURDFFiles(urdf_filenames, false);
-        buildFromUrdfModelInterface(model, floating_base);
-    }
-
-    template <typename Scalar>
+    template <typename OrientationRepresentation>
     void ClusterTreeModel<Scalar>::buildFromUrdfModelInterface(
         const UrdfModelPtr model, bool floating_base)
     {
@@ -40,7 +25,7 @@ namespace grbda
             std::string parent_name = "ground";
             SpatialInertia<Scalar> inertia(root->inertial);
             spatial::Transform<Scalar> xtree = spatial::Transform<Scalar>{};
-            using Free = ClusterJoints::Free<Scalar, ori_representation::Quaternion>;
+            using Free = ClusterJoints::Free<Scalar, OrientationRepresentation>;
             appendBody<Free>(name, inertia, parent_name, xtree);
         }
         else
@@ -374,5 +359,19 @@ namespace grbda
     template class ClusterTreeModel<double>;
     template class ClusterTreeModel<float>;
     template class ClusterTreeModel<casadi::SX>;
+
+    template void ClusterTreeModel<double>::buildFromUrdfModelInterface<ori_representation::Quaternion>(
+        const UrdfModelPtr model, bool floating_base);
+    template void ClusterTreeModel<float>::buildFromUrdfModelInterface<ori_representation::Quaternion>(
+        const UrdfModelPtr model, bool floating_base);
+    template void ClusterTreeModel<casadi::SX>::buildFromUrdfModelInterface<ori_representation::Quaternion>(
+        const UrdfModelPtr model, bool floating_base);
+    template void ClusterTreeModel<double>::buildFromUrdfModelInterface<ori_representation::RollPitchYaw>(
+        const UrdfModelPtr model, bool floating_base);
+    template void ClusterTreeModel<float>::buildFromUrdfModelInterface<ori_representation::RollPitchYaw>(
+        const UrdfModelPtr model, bool floating_base);
+    template void ClusterTreeModel<casadi::SX>::buildFromUrdfModelInterface<ori_representation::RollPitchYaw>(
+        const UrdfModelPtr model, bool floating_base);
+
 
 } // namespace grbda


### PR DESCRIPTION
Allows to build a model with a quaternion or roll pitch yaw representation for the floating base.

Added a test to test this feature. It does not work for many urdfs when using casadi::SX 