### PR TITLE
link PinocchioHelpers with gtest

### DIFF
--- a/Benchmarking/CMakeLists.txt
+++ b/Benchmarking/CMakeLists.txt
@@ -27,7 +27,7 @@ endif()
 
 file(GLOB_RECURSE HELPER_SRCS "src/*Helpers.cpp")
 add_library(benchmarkHelpers ${HELPER_SRCS})
-target_link_libraries(benchmarkHelpers ${PROJECT_NAME} ${PINOCCHIO_LIBRARIES} console_bridge)
+target_link_libraries(benchmarkHelpers ${PROJECT_NAME} ${PINOCCHIO_LIBRARIES} console_bridge gtest)
 
 add_executable(pinocchio_benchmark src/pinocchioBenchmark.cpp)
 target_link_libraries(pinocchio_benchmark benchmarkHelpers)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To run the unit tests and bencmarks
 - Run CMake: `cmake ..`
 - Build: `make`
 - Unit tests can be run all at once with `ctest` or individually with `./bin/<name-of-unit-test-binary>`
-- The benchmark can be run with `./bin/pinocchio_benchmark`
+- The benchmark can be run with `./bin/pinocchio_benchmark` after installing the benchmark dependencies following [this script](scripts/install_benchmark_dependencies.sh)
 
 To incorporate the library into your own project, see [Configuration](#configuration).
 


### PR DESCRIPTION
Prevent build failure due to PinocchioHelpers not getting linked to gtest